### PR TITLE
Feat/card 9 : 공통 컴포넌트 구현 및 시맨틱 태그 구성

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -7,9 +7,9 @@ type MainLayoutProps = {
 
 export default function MainLayout({ children }: MainLayoutProps) {
   return (
-    <div className="flex min-h-screen flex-col gap-10">
+    <div className="flex min-h-screen flex-col gap-[40px]">
       <Header />
-      <main className="mx-auto max-w-[1440px] lg:px-[190px]">{children}</main>
+      <div className="mx-auto flex w-full max-w-7xl flex-col px-4">{children}</div>
     </div>
   );
 }

--- a/src/app/(main)/posts/page.tsx
+++ b/src/app/(main)/posts/page.tsx
@@ -1,16 +1,38 @@
-'use client';
+'use client'; // 삭제
 
+import Card from '@/components/common/Card';
 import { supabase } from '@/lib/supabase';
+import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
 export default function Page() {
+  const router = useRouter();
   // test
   useEffect(() => {
     supabase.from('posts').select('*').then(console.log);
   }, []);
+
+  const handleCardClicked = () => {
+    router.push('/post/[id]');
+  };
+
   return (
-    <>
-      <main>Posts</main>
-    </>
+    <main>
+      {/*test*/}
+      <Card
+        content="엄청 긴 내용이예요.😉 엄청 긴 내용이예요.😉 엄청 긴 내용이예요.😉 엄청 긴 내용이예요.😉 엄청 긴 내용이예요.😉 엄청 긴 내용이예요.😉 엄청 긴 내용이예요.😉"
+        createAt="2025.04.10"
+        likes={3}
+        onClick={handleCardClicked}
+        title="새벽입니다"
+      />
+      <Card
+        content="엄청 긴 내용이예요.😉 엄청 긴 내용이예요.😉 엄청 긴 내용이예요.😉 엄청 긴 내용이예요.😉 엄청 긴 내용이예요.😉 엄청 긴 내용이예요.😉 엄청 긴 내용이예요.😉"
+        createAt="2025.04.10"
+        likes={3}
+        onClick={handleCardClicked}
+        title="새벽입니다"
+      />
+    </main>
   );
 }

--- a/src/components/common/Card/index.tsx
+++ b/src/components/common/Card/index.tsx
@@ -12,18 +12,18 @@ type CardProps = {
 
 export default function Card({ title, content, createAt, likes, onClick }: CardProps) {
   return (
-    <section className={cardStyles} onClick={onClick}>
+    <article className={cardStyles} onClick={onClick}>
       <div className="flex flex-col gap-2">
         <span className="text-[13px] text-[#666666]">익명</span>
-        <div className="flex flex-col gap-1">
+        <header className="flex flex-col gap-1">
           <h2 className="text-2xl font-bold">{title}</h2>
-          <p className="truncate">{content}</p>
-        </div>
+        </header>
+        <p className="truncate">{content}</p>
         <footer className="flex justify-between">
           <span className="text-[13px]">{createAt}</span>
           <div>🖤{likes}</div>
         </footer>
       </div>
-    </section>
+    </article>
   );
 }

--- a/src/components/common/Card/index.tsx
+++ b/src/components/common/Card/index.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { cardStyles } from './styes';
+
+type CardProps = {
+  title: string;
+  content: string;
+  createAt: string;
+  likes: number;
+  onClick: () => void;
+};
+
+export default function Card({ title, content, createAt, likes, onClick }: CardProps) {
+  return (
+    <section className={cardStyles} onClick={onClick}>
+      <div className="flex flex-col gap-2">
+        <span className="text-[13px] text-[#666666]">익명</span>
+        <div className="flex flex-col gap-1">
+          <h2 className="text-2xl font-bold">{title}</h2>
+          <p className="truncate">{content}</p>
+        </div>
+        <footer className="flex justify-between">
+          <span className="text-[13px]">{createAt}</span>
+          <div>🖤{likes}</div>
+        </footer>
+      </div>
+    </section>
+  );
+}

--- a/src/components/common/Card/styes.ts
+++ b/src/components/common/Card/styes.ts
@@ -1,0 +1,1 @@
+export const cardStyles = 'mb-5 w-full cursor-pointer rounded-lg border bg-white px-5 py-4';

--- a/src/components/common/Card/styes.ts
+++ b/src/components/common/Card/styes.ts
@@ -1,1 +1,2 @@
-export const cardStyles = 'mb-5 w-full cursor-pointer rounded-lg border bg-white px-5 py-4';
+export const cardStyles =
+  'mb-5 w-full cursor-pointer rounded-lg border bg-white px-5 py-4 transition-transform duration-200 ease-in-out hover:scale-[1.01]';

--- a/src/components/common/button/styles.ts
+++ b/src/components/common/button/styles.ts
@@ -1,5 +1,5 @@
 export const baseStyles =
-  'flex justify-center items-center box-border hover:opacity-80 cursor-pointer rounded-lg bg-black text-white transition-transform duration-200 ease-in-out hover:scale-105';
+  'flex justify-center items-center box-border hover:opacity-80 cursor-pointer rounded-lg bg-black text-white transition-transform duration-200 ease-in-out hover:scale-[1.05]';
 
 export const disabledStyles = 'cursor-not-allowed opacity-70';
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -5,7 +5,7 @@ export default function Header() {
   return (
     <header className="w-full bg-white py-5">
       <div className="mx-auto flex max-w-7xl items-center justify-between px-4">
-        <Link href={'/posts'}>
+        <Link href={'/'}>
           <Image
             src="/icons/logo.svg"
             alt="logo"


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 해당 작업이 해결한 이슈 번호를 작성합니다. -->
Closes #9

## 📋 작업 사항
<!-- 작업한 내용을 기록합니다. --> 
- 공통 카드 컴포넌트 구현 및 스타일 분리 (style.ts)
- 카드 hover 애니메이션 적용
- 카드 컴포넌트 시맨틱 태그로 구성

## 📝 기타 참고 사항
<!-- PR에 포함된 변경 사항 외에 공유할 내용이 있다면 작성합니다. --> 
- 카드 클릭 시 `/post/[id]` 라우팅 처리는 다음 작업에서 구현 예정
