### PR TITLE
Feat/posts-get-13 : /posts 페이지에서 데이터 페칭 및 렌더링

### DIFF
--- a/src/app/(main)/posts/PostCardList.tsx
+++ b/src/app/(main)/posts/PostCardList.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import Card from '@/components/common/Card';
+import { Post } from '@/types/post';
+import { useRouter } from 'next/navigation';
+
+export default function PostCardList({ posts }: { posts: Post[] }) {
+  const router = useRouter();
+
+  const handlePostClicked = (postId: number) => {
+    router.push(`/post/${postId}`);
+  };
+  return (
+    <div>
+      {posts &&
+        posts.map((post) => (
+          <Card
+            key={post.id}
+            title={post.title}
+            content={post.content}
+            createAt={post.created_at}
+            likes={post.likes}
+            onClick={() => {
+              handlePostClicked(post.id);
+            }}
+          />
+        ))}
+    </div>
+  );
+}

--- a/src/app/(main)/posts/PostCardList.tsx
+++ b/src/app/(main)/posts/PostCardList.tsx
@@ -2,6 +2,7 @@
 
 import Card from '@/components/common/Card';
 import { Post } from '@/types/post';
+import FormatDate from '@/utils/FormatDate';
 import { useRouter } from 'next/navigation';
 
 export default function PostCardList({ posts }: { posts: Post[] }) {
@@ -18,7 +19,7 @@ export default function PostCardList({ posts }: { posts: Post[] }) {
             key={post.id}
             title={post.title}
             content={post.content}
-            createAt={post.created_at}
+            createAt={FormatDate(post.created_at)}
             likes={post.likes}
             onClick={() => {
               handlePostClicked(post.id);

--- a/src/app/(main)/posts/PostCardList.tsx
+++ b/src/app/(main)/posts/PostCardList.tsx
@@ -2,7 +2,7 @@
 
 import Card from '@/components/common/Card';
 import { Post } from '@/types/post';
-import FormatDate from '@/utils/FormatDate';
+import formatDate from '@/utils/formatDate';
 import { useRouter } from 'next/navigation';
 
 export default function PostCardList({ posts }: { posts: Post[] }) {
@@ -19,7 +19,7 @@ export default function PostCardList({ posts }: { posts: Post[] }) {
             key={post.id}
             title={post.title}
             content={post.content}
-            createAt={FormatDate(post.created_at)}
+            createAt={formatDate(post.created_at)}
             likes={post.likes}
             onClick={() => {
               handlePostClicked(post.id);

--- a/src/app/(main)/posts/page.tsx
+++ b/src/app/(main)/posts/page.tsx
@@ -1,38 +1,19 @@
-'use client'; // 삭제
-
-import Card from '@/components/common/Card';
 import { supabase } from '@/lib/supabase';
-import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
+import PostCardList from './PostCardList';
+import { Post } from '@/types/post';
 
-export default function Page() {
-  const router = useRouter();
-  // test
-  useEffect(() => {
-    supabase.from('posts').select('*').then(console.log);
-  }, []);
+export default async function Page() {
+  const { error, data } = await supabase.from('posts').select('*');
 
-  const handleCardClicked = () => {
-    router.push('/post/[id]');
-  };
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  const posts: Post[] = data ?? [];
 
   return (
     <main>
-      {/*test*/}
-      <Card
-        content="엄청 긴 내용이예요.😉 엄청 긴 내용이예요.😉 엄청 긴 내용이예요.😉 엄청 긴 내용이예요.😉 엄청 긴 내용이예요.😉 엄청 긴 내용이예요.😉 엄청 긴 내용이예요.😉"
-        createAt="2025.04.10"
-        likes={3}
-        onClick={handleCardClicked}
-        title="새벽입니다"
-      />
-      <Card
-        content="엄청 긴 내용이예요.😉 엄청 긴 내용이예요.😉 엄청 긴 내용이예요.😉 엄청 긴 내용이예요.😉 엄청 긴 내용이예요.😉 엄청 긴 내용이예요.😉 엄청 긴 내용이예요.😉"
-        createAt="2025.04.10"
-        likes={3}
-        onClick={handleCardClicked}
-        title="새벽입니다"
-      />
+      <PostCardList posts={posts} />
     </main>
   );
 }

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -1,0 +1,8 @@
+// response type
+export type Post = {
+  id: number;
+  title: string;
+  content: string;
+  likes: number;
+  created_at: string;
+};

--- a/src/utils/FormatDate.ts
+++ b/src/utils/FormatDate.ts
@@ -1,0 +1,4 @@
+// ISO to local time
+export default function FormatDate(createAt: string) {
+  return new Date(createAt).toLocaleString();
+}

--- a/src/utils/FormatDate.ts
+++ b/src/utils/FormatDate.ts
@@ -1,4 +1,4 @@
 // ISO to local time
-export default function FormatDate(createAt: string) {
+export default function formatDate(createAt: string) {
   return new Date(createAt).toLocaleString();
 }


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 해당 작업이 해결한 이슈 번호를 작성합니다. -->
Closes #13

## 📋 작업 사항
<!-- 작업한 내용을 기록합니다. --> 
- `/posts` 페이지에서 데이터 페칭 및 PostCardList 에서 렌더링
- post 클릭 시 `/post[id]` 로 라우팅
- 게시글 생성일을 포맷팅 하는 formateDate() 추가 및 분리

## 📝 기타 참고 사항
